### PR TITLE
Error message passed if pcap_compile failed

### DIFF
--- a/lib/libnids-1.21_patched/src/libnids.c
+++ b/lib/libnids-1.21_patched/src/libnids.c
@@ -586,7 +586,10 @@ int nids_init()
 	struct bpf_program fcode;
 
 	if (pcap_compile(desc, &fcode, nids_params.pcap_filter, 1, mask) <
-	    0) return 0;
+	    0) {
+        strncat(nids_errbuf, pcap_geterr(desc), sizeof(nids_errbuf) - 1);
+        return 0;
+    }
 	if (pcap_setfilter(desc, &fcode) == -1)
 	    return 0;
     }


### PR DESCRIPTION
Previously if you the pcap_filter (-p) was not valid an uninformative "ERROR: Libnids not initialized" appeared. This commit shows the pcap error message like: "ERROR: eth0: You don't have permission to capture on that device (socket: Operation not permitted)" or "ERROR: syntax error in filter expression: syntax error"